### PR TITLE
Bundle install fix

### DIFF
--- a/roles/bootstrap/tasks/bundle_install.yml
+++ b/roles/bootstrap/tasks/bundle_install.yml
@@ -15,12 +15,11 @@
   debug:
     msg: "SSH Version: {{ sshversion.output }}"
 
-
 ##################################################
 - name: install openssh bundle
   telnet:
     user: root
-    password: 
+    password:
     login_prompt: "login: "
     prompts:
       - "[>|#]"
@@ -66,11 +65,10 @@
   debug:
     msg: "Wget Version: {{ wgetversion.output }}"
 
-
 - name: install wget bundle
   telnet:
     user: root
-    password: 
+    password:
     login_prompt: "login: "
     prompts:
       - "[>|#]"
@@ -78,7 +76,6 @@
       - "/sbin/sh /usr/nekoware/dist/wget_install.sh"
     timeout:  900
   when: wgetversion.output | select('search',' GNU') | list | count == 0
- 
 
 - name: Verify wget
   telnet:
@@ -124,7 +121,6 @@
     command:
       - "/sbin/sh /usr/nekoware/dist/python_install.sh"
   when: pyversion.output | select('search','Python') | list | count == 0
-
 
 - name: Verify python
   telnet:

--- a/roles/bootstrap/tasks/bundle_install.yml
+++ b/roles/bootstrap/tasks/bundle_install.yml
@@ -18,7 +18,7 @@
     prompts:
       - "[>|#]"
     command:
-      - "/sbin/sh /usr/nekoware/dist/openssh_install.sh"
+      - "/usr/nekoware/dist/openssh_install.sh > /tmp/openssh_install.log"
   when: sshversion.output | select('search','OpenSSH') | list | count == 0
 
 - name: Verify openssh
@@ -58,7 +58,7 @@
     prompts:
       - "[>|#]"
     command:
-      - "/sbin/sh /usr/nekoware/dist/wget_install.sh"
+      - "/usr/nekoware/dist/wget_install.sh > /tmp/wget_install.log"
     timeout:  900
   when: wgetversion.output | select('search',' GNU') | list | count == 0
 
@@ -100,7 +100,7 @@
       - "[>|#]"
     timeout:  2500
     command:
-      - "/sbin/sh /usr/nekoware/dist/python_install.sh"
+      - "/usr/nekoware/dist/python_install.sh > /tmp/python_install.log"
   when: pyversion.output | select('search','Python') | list | count == 0
 
 - name: Verify python

--- a/roles/bootstrap/tasks/bundle_install.yml
+++ b/roles/bootstrap/tasks/bundle_install.yml
@@ -10,10 +10,6 @@
       - "/usr/nekoware/bin/ssh -v"
   register: sshversion
 
-- name: Print SSH version
-  debug:
-    msg: "SSH Version: {{ sshversion.output }}"
-
 - name: install openssh bundle
   telnet:
     user: root
@@ -53,11 +49,6 @@
     command:
       - "/usr/nekoware/bin/wget --version"
   register: wgetversion
-
-
-- name: Print wget version
-  debug:
-    msg: "Wget Version: {{ wgetversion.output }}"
 
 - name: install wget bundle
   telnet:

--- a/roles/bootstrap/tasks/bundle_install.yml
+++ b/roles/bootstrap/tasks/bundle_install.yml
@@ -26,7 +26,7 @@
       - "[>|#]"
     command:
       - "/sbin/sh /usr/nekoware/dist/openssh_install.sh"
-  when: sshversion.output | select('search','OpenSSH') | list | count < 1
+  when: sshversion.output | select('search','OpenSSH') | list | count == 0
 
 - name: Verify openssh
   telnet:
@@ -46,7 +46,7 @@
 - name: Quit if OpenSSH failed to install properly
   fail:
     msg: "OpenSSH failed to install properly. Telnet to your SGI and install it manually, then re-run this play."
-  when: sshversion.output | select('search','OpenSSH') | list | count < 1
+  when: sshversion.output | select('search','OpenSSH') | list | count == 0
   # per debug, telnet's output is a list. We have to select search it, then count it.
 
 ##################################################
@@ -77,8 +77,7 @@
     command:
       - "/sbin/sh /usr/nekoware/dist/wget_install.sh"
     timeout:  900
-#  when: wgetversion.output | select('search',' GNU Wget 1.11.3') | list | count < 0
-  when: wgetversion.output | select('search',' GNU') | list | count < 1
+  when: wgetversion.output | select('search',' GNU') | list | count == 0
  
 
 - name: Verify wget
@@ -99,7 +98,7 @@
 - name: Quit if wget failed to install properly
   fail:
     msg: "wget failed to install properly.  Telnet to your SGI and install it manually, then re-run this play."
-  when: wgetversion.output | select('search','Wget') | list | count > 0
+  when: wgetversion.output | select('search','Wget') | list | count == 0
   # per debug, telnet's output is a list. We have to select search it, then count it.
 
 ##################################################
@@ -124,7 +123,7 @@
     timeout:  2500
     command:
       - "/sbin/sh /usr/nekoware/dist/python_install.sh"
-  when: pyversion.output | select('search','Python') | list | count > 0
+  when: pyversion.output | select('search','Python') | list | count == 0
 
 
 - name: Verify python
@@ -145,5 +144,5 @@
 - name: Quit if Python failed to install properly
   fail:
     msg: "Python failed to install properly.  Telnet to your SGI and install it manually, then re-run this play."
-  when: pyversion.output | select('search','Python') | list | count < 0
+  when: pyversion.output | select('search','Python') | list | count == 0
   # per debug, telnet's output is a list. We have to select search it, then count it.

--- a/roles/bootstrap/tasks/bundle_install.yml
+++ b/roles/bootstrap/tasks/bundle_install.yml
@@ -10,12 +10,10 @@
       - "/usr/nekoware/bin/ssh -v"
   register: sshversion
 
-##################################################
 - name: Print SSH version
   debug:
     msg: "SSH Version: {{ sshversion.output }}"
 
-##################################################
 - name: install openssh bundle
   telnet:
     user: root
@@ -37,10 +35,6 @@
     command:
       - "/usr/nekoware/bin/ssh -v"
   register: sshversion
-
-#- name: print output
-#  debug:
-#    msg: "{{ sshversion }}"
 
 - name: Quit if OpenSSH failed to install properly
   fail:
@@ -88,10 +82,6 @@
       - "/usr/nekoware/bin/wget --version"
   register: wgetversion
 
-#- name: print output
-#  debug:
-#    msg: "{{ wgetversion }}"
-
 - name: Quit if wget failed to install properly
   fail:
     msg: "wget failed to install properly.  Telnet to your SGI and install it manually, then re-run this play."
@@ -132,10 +122,6 @@
     command:
       - "/usr/nekoware/bin/python --version"
   register: pyversion
-
-# - name: print output
-#   debug:
-#     msg: "{{ pyversion }}"
 
 - name: Quit if Python failed to install properly
   fail:


### PR DESCRIPTION
Try preventing Ansible hanging when installing nekoware packages to slower machines by redirecting output to file. 

I do not fully understand why it seems to work. Possibly inst behaves somehow differently when stdout is not terminal. However, this was tested to work with Indy (150MHz R5000) by removing all neko_* packages and re-running.

Further, the pull request fixes several when-conditionals which seemed erroneous or unconventional.
